### PR TITLE
Fixed define sticking on 'Opening Dictionary'

### DIFF
--- a/commands/define.js
+++ b/commands/define.js
@@ -19,6 +19,8 @@ module.exports = {
                     } catch (err) {
                         message.edit("`No results found!`");
                     }
+                } else {
+                    message.edit("`No results found!`");
                 }
             });
         });


### PR DESCRIPTION
Sometimes a definition lookup fails with a status code of 200. I made it so that the module handles these instances instead of failing silently as in the screenshot provided.

![image](https://cloud.githubusercontent.com/assets/1059362/18024972/f2109fc4-6bd6-11e6-9ec6-756ebc27b07a.png)
