### PR TITLE
Fix a small issue in define

### DIFF
--- a/src/commands/define.js
+++ b/src/commands/define.js
@@ -9,6 +9,10 @@ module.exports = {
         superagent.get(`https://glosbe.com/gapi/translate?from=en&dest=en&format=json&phrase=${message.content}`)
           .then((res) => res.body)
           .then((res) => {
+            if (res.tuc == undefined) {
+              msg.edit('**No results found!**')
+              return;
+            }
             const final = [`**Definitions for __${message.content}__:**`];
             for (let [index, item] of Object.entries(res.tuc.filter(t => t.meanings)[0].meanings.slice(0, 5))) {
               item = item.text


### PR DESCRIPTION
When defining a word that has no definition (try with random key mashing) the bot would still print **No results found!** due to the `.catch`, however it would also error in the for loop. If the content existed of multiple words it would be:

```
TypeError: Cannot read property 'meanings' of undefined
    at superagent.get.then.then (<Path-To-App-And-Line>)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```

And if the content existed of a single word then the error would be:

```
TypeError: Cannot read property 'filter' of undefined
    at superagent.get.then.then (<Path-To-App-And-Line>)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```

By simple ensuring that `tuc` exists prior to continuing this issue is avoided and there will be a lot less spam in an error log. A simple `console.log(res)` right after `.then((res) => {` revealed that if no definition is found there is no `tuc`

log with definition:

```
{ result: 'ok',
  tuc:
   [ { meanings: [Object], meaningId: null, authors: [Object] },
     { phrase: [Object],
       meanings: [Object],
       meaningId: null,
       authors: [Object] } ],
  phrase: 'hello',
  from: 'en',
  dest: 'en',
  authors:
   { '2736':
      { U: 'http://www.csse.monash.edu.au/~jwb/j_jmdict.html',
        id: 2736,
        N: 'JMdict-Japanese-Multilingual-Dictio...',
        url: 'https://glosbe.com/source/2736' },
     '60172':
      { U: 'http://www.omegawiki.org/',
        id: 60172,
        N: 'omegawiki',
        url: 'https://glosbe.com/source/60172' } } }
```

Log without definition:

```
{ result: 'ok',
  phrase: 'hellow',
  from: 'en',
  dest: 'en',
  authors: {} }
```
